### PR TITLE
feat(auth): Google OAuth helper for entity SSO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@programisto/edrm-user",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@programisto/edrm-user",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "license": "ISC",
       "dependencies": {
         "@programisto/endurance": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@programisto/edrm-user",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "publishConfig": {
     "access": "public"
   },
   "description": "edurance module for user management",
   "type": "module",
   "main": "app.js",
+  "exports": {
+    ".": "./dist/app.js",
+    "./google-oauth": "./dist/modules/user/lib/google-oauth.helper.js"
+  },
   "scripts": {
     "start": "node ./dist/bin/www",
     "dev": "tsc-watch --onSuccess \"node ./dist/bin/www\"",

--- a/src/modules/user/lib/google-oauth.helper.ts
+++ b/src/modules/user/lib/google-oauth.helper.ts
@@ -1,0 +1,131 @@
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
+
+export const DEFAULT_GOOGLE_OAUTH_SCOPES = ['openid', 'email', 'profile'] as const;
+
+export type BuildGoogleOAuthAuthUrlParams = {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    scopes?: readonly string[];
+    /** Restrict sign-in to a Google Workspace hosted domain (optional). */
+    hostedDomain?: string;
+};
+
+export type ExchangeGoogleOAuthAuthCodeParams = {
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    redirectUri: string;
+};
+
+function normalizeEmail(raw: unknown): string | null {
+    if (typeof raw !== 'string') return null;
+    const email = raw.trim().toLowerCase();
+    return email || null;
+}
+
+function emailFromIdToken(idToken: string): string | null {
+    const parts = idToken.split('.');
+    if (parts.length !== 3) return null;
+    try {
+        const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+        const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
+        const payload = JSON.parse(Buffer.from(b64 + pad, 'base64').toString('utf8')) as {
+            email?: string;
+            email_verified?: boolean;
+        };
+        if (payload.email_verified === false) return null;
+        return normalizeEmail(payload.email);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Build Google OAuth 2.0 authorization URL (authorization code flow).
+ */
+export function buildGoogleOAuthAuthUrl(params: BuildGoogleOAuthAuthUrlParams): string {
+    const clientId = params.clientId?.trim();
+    const redirectUri = params.redirectUri?.trim();
+    const state = params.state?.trim();
+    if (!clientId || !redirectUri || !state) {
+        throw new Error('buildGoogleOAuthAuthUrl: clientId, redirectUri and state are required');
+    }
+    const scopes = params.scopes?.length ? params.scopes : DEFAULT_GOOGLE_OAUTH_SCOPES;
+    const q = new URLSearchParams({
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: scopes.join(' '),
+        state,
+        access_type: 'online',
+        prompt: 'select_account'
+    });
+    const hd = params.hostedDomain?.trim();
+    if (hd) q.set('hd', hd);
+    return `${GOOGLE_AUTH_URL}?${q.toString()}`;
+}
+
+/**
+ * Exchange authorization code for tokens and resolve the user email.
+ */
+export async function exchangeGoogleOAuthAuthCode(
+    params: ExchangeGoogleOAuthAuthCodeParams
+): Promise<{ email: string | null }> {
+    const clientId = params.clientId?.trim();
+    const clientSecret = params.clientSecret?.trim();
+    const code = params.code?.trim();
+    const redirectUri = params.redirectUri?.trim();
+    if (!clientId || !clientSecret || !code || !redirectUri) {
+        throw new Error('exchangeGoogleOAuthAuthCode: clientId, clientSecret, code and redirectUri are required');
+    }
+
+    const body = new URLSearchParams({
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code'
+    });
+
+    const tokenRes = await fetch(GOOGLE_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body
+    });
+
+    if (!tokenRes.ok) {
+        const errText = await tokenRes.text().catch(() => '');
+        throw new Error(`Google token exchange failed (${tokenRes.status}): ${errText}`);
+    }
+
+    const tokenData = (await tokenRes.json()) as {
+        access_token?: string;
+        id_token?: string;
+    };
+
+    if (tokenData.id_token) {
+        const fromId = emailFromIdToken(tokenData.id_token);
+        if (fromId) return { email: fromId };
+    }
+
+    const accessToken = tokenData.access_token?.trim();
+    if (!accessToken) {
+        return { email: null };
+    }
+
+    const userRes = await fetch(GOOGLE_USERINFO_URL, {
+        headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    if (!userRes.ok) {
+        return { email: null };
+    }
+
+    const user = (await userRes.json()) as { email?: string; verified_email?: boolean };
+    if (user.verified_email === false) {
+        return { email: null };
+    }
+    return { email: normalizeEmail(user.email) };
+}

--- a/src/modules/user/lib/google-oauth.helper.ts
+++ b/src/modules/user/lib/google-oauth.helper.ts
@@ -158,8 +158,7 @@ export async function exchangeGoogleOAuthAuthCode(
 
     if (tokenData.id_token) {
         const claims = await verifiedGoogleIdTokenClaims(tokenData.id_token, clientId);
-        const fromId = claims ? emailFromClaims(claims, hostedDomain) : null;
-        if (fromId) return { email: fromId };
+        if (claims) return { email: emailFromClaims(claims, hostedDomain) };
     }
 
     const accessToken = tokenData.access_token?.trim();

--- a/src/modules/user/lib/google-oauth.helper.ts
+++ b/src/modules/user/lib/google-oauth.helper.ts
@@ -1,6 +1,10 @@
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
+const GOOGLE_CERTS_URL = 'https://www.googleapis.com/oauth2/v1/certs';
+const GOOGLE_ID_TOKEN_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'];
 
 export const DEFAULT_GOOGLE_OAUTH_SCOPES = ['openid', 'email', 'profile'] as const;
 
@@ -9,7 +13,7 @@ export type BuildGoogleOAuthAuthUrlParams = {
     redirectUri: string;
     state: string;
     scopes?: readonly string[];
-    /** Restrict sign-in to a Google Workspace hosted domain (optional). */
+    /** Hint account selection for a Google Workspace domain (optional). */
     hostedDomain?: string;
 };
 
@@ -18,7 +22,18 @@ export type ExchangeGoogleOAuthAuthCodeParams = {
     clientSecret: string;
     code: string;
     redirectUri: string;
+    /** Enforce a Google Workspace hosted domain from verified Google claims (optional). */
+    hostedDomain?: string;
 };
+
+type GoogleIdentityClaims = {
+    email?: string;
+    email_verified?: boolean;
+    verified_email?: boolean;
+    hd?: string;
+};
+
+type GoogleIdTokenPayload = JwtPayload & GoogleIdentityClaims;
 
 function normalizeEmail(raw: unknown): string | null {
     if (typeof raw !== 'string') return null;
@@ -26,18 +41,52 @@ function normalizeEmail(raw: unknown): string | null {
     return email || null;
 }
 
-function emailFromIdToken(idToken: string): string | null {
-    const parts = idToken.split('.');
-    if (parts.length !== 3) return null;
+function normalizeHostedDomain(raw: unknown): string | null {
+    if (typeof raw !== 'string') return null;
+    const hostedDomain = raw.trim().toLowerCase();
+    return hostedDomain || null;
+}
+
+function hostedDomainMatches(raw: unknown, expected: string | null): boolean {
+    if (!expected) return true;
+    return normalizeHostedDomain(raw) === expected;
+}
+
+function emailFromClaims(claims: GoogleIdentityClaims, expectedHostedDomain: string | null): string | null {
+    if (claims.email_verified === false || claims.verified_email === false) return null;
+    if (!hostedDomainMatches(claims.hd, expectedHostedDomain)) return null;
+    return normalizeEmail(claims.email);
+}
+
+async function fetchGoogleOAuthCerts(): Promise<Record<string, string>> {
+    const certRes = await fetch(GOOGLE_CERTS_URL);
+    if (!certRes.ok) return {};
+    const certs = (await certRes.json()) as Record<string, unknown>;
+    return Object.entries(certs).reduce<Record<string, string>>((acc, [kid, cert]) => {
+        if (typeof cert === 'string') acc[kid] = cert;
+        return acc;
+    }, {});
+}
+
+async function verifiedGoogleIdTokenClaims(
+    idToken: string,
+    clientId: string
+): Promise<GoogleIdTokenPayload | null> {
     try {
-        const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-        const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
-        const payload = JSON.parse(Buffer.from(b64 + pad, 'base64').toString('utf8')) as {
-            email?: string;
-            email_verified?: boolean;
-        };
-        if (payload.email_verified === false) return null;
-        return normalizeEmail(payload.email);
+        const decoded = jwt.decode(idToken, { complete: true });
+        if (!decoded || typeof decoded === 'string') return null;
+        const kid = decoded.header.kid;
+        if (!kid) return null;
+        const certs = await fetchGoogleOAuthCerts();
+        const cert = certs[kid];
+        if (!cert) return null;
+        const verified = jwt.verify(idToken, cert, {
+            algorithms: ['RS256'],
+            audience: clientId,
+            issuer: GOOGLE_ID_TOKEN_ISSUERS
+        });
+        if (typeof verified !== 'object' || verified === null) return null;
+        return verified as GoogleIdTokenPayload;
     } catch {
         return null;
     }
@@ -78,6 +127,7 @@ export async function exchangeGoogleOAuthAuthCode(
     const clientSecret = params.clientSecret?.trim();
     const code = params.code?.trim();
     const redirectUri = params.redirectUri?.trim();
+    const hostedDomain = normalizeHostedDomain(params.hostedDomain);
     if (!clientId || !clientSecret || !code || !redirectUri) {
         throw new Error('exchangeGoogleOAuthAuthCode: clientId, clientSecret, code and redirectUri are required');
     }
@@ -107,7 +157,8 @@ export async function exchangeGoogleOAuthAuthCode(
     };
 
     if (tokenData.id_token) {
-        const fromId = emailFromIdToken(tokenData.id_token);
+        const claims = await verifiedGoogleIdTokenClaims(tokenData.id_token, clientId);
+        const fromId = claims ? emailFromClaims(claims, hostedDomain) : null;
         if (fromId) return { email: fromId };
     }
 
@@ -123,9 +174,6 @@ export async function exchangeGoogleOAuthAuthCode(
         return { email: null };
     }
 
-    const user = (await userRes.json()) as { email?: string; verified_email?: boolean };
-    if (user.verified_email === false) {
-        return { email: null };
-    }
-    return { email: normalizeEmail(user.email) };
+    const user = (await userRes.json()) as GoogleIdentityClaims;
+    return { email: emailFromClaims(user, hostedDomain) };
 }

--- a/src/modules/user/middlewares/auth.middleware.ts
+++ b/src/modules/user/middlewares/auth.middleware.ts
@@ -101,7 +101,7 @@ class CustomAccessControl extends EnduranceAccessControl {
         res.status(403).json({
           message: 'Access denied: Insufficient permissions',
           required: permissions,
-          userPermissions: userPermissions
+          userPermissions
         });
         return;
       }

--- a/test/google-oauth.helper.test.ts
+++ b/test/google-oauth.helper.test.ts
@@ -1,10 +1,29 @@
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import jwt from 'jsonwebtoken';
 import {
     buildGoogleOAuthAuthUrl,
     exchangeGoogleOAuthAuthCode,
     DEFAULT_GOOGLE_OAUTH_SCOPES
 } from '../src/modules/user/lib/google-oauth.helper.js';
+
+function signedGoogleIdToken(claims: { email?: string; email_verified?: boolean; hd?: string }): {
+    idToken: string;
+    publicKey: string;
+} {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    const idToken = jwt.sign(claims, privateKeyPem, {
+        algorithm: 'RS256',
+        audience: 'cid',
+        expiresIn: '5m',
+        issuer: 'https://accounts.google.com',
+        keyid: 'test-key'
+    });
+    return { idToken, publicKey: publicKeyPem };
+}
 
 describe('google-oauth.helper', () => {
     describe('buildGoogleOAuthAuthUrl', () => {
@@ -60,14 +79,22 @@ describe('google-oauth.helper', () => {
             globalThis.fetch = originalFetch;
         });
 
-        it('returns email from id_token claims', async () => {
-            const idToken =
-                'eyJhbGciOiJSUzI1NiJ9.eyJlbWFpbCI6IlVzZXJAZXhhbXBsZS5DT00iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZX0.sig';
+        it('returns email from verified id_token claims', async () => {
+            const { idToken, publicKey } = signedGoogleIdToken({
+                email: 'User@Example.COM',
+                email_verified: true
+            });
 
             globalThis.fetch = (async (input: string | URL) => {
                 const url = String(input);
                 if (url === 'https://oauth2.googleapis.com/token') {
                     return new Response(JSON.stringify({ id_token: idToken, access_token: 'at' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (url === 'https://www.googleapis.com/oauth2/v1/certs') {
+                    return new Response(JSON.stringify({ 'test-key': publicKey }), {
                         status: 200,
                         headers: { 'Content-Type': 'application/json' }
                     });
@@ -82,6 +109,79 @@ describe('google-oauth.helper', () => {
                 redirectUri: 'https://app.example.com/cb'
             });
             assert.equal(out.email, 'user@example.com');
+        });
+
+        it('does not trust unverified id_token claims', async () => {
+            const idToken =
+                'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJlbWFpbCI6ImZha2VAZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZX0.sig';
+
+            globalThis.fetch = (async (input: string | URL) => {
+                const url = String(input);
+                if (url === 'https://oauth2.googleapis.com/token') {
+                    return new Response(JSON.stringify({ id_token: idToken, access_token: 'access-xyz' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (url === 'https://www.googleapis.com/oauth2/v1/certs') {
+                    return new Response(JSON.stringify({ 'test-key': 'not-a-valid-public-key' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (url === 'https://www.googleapis.com/oauth2/v3/userinfo') {
+                    return new Response(
+                        JSON.stringify({ email: 'info@example.com', verified_email: true }),
+                        {
+                            status: 200,
+                            headers: { 'Content-Type': 'application/json' }
+                        }
+                    );
+                }
+                throw new Error(`unexpected fetch: ${url}`);
+            }) as typeof fetch;
+
+            const out = await exchangeGoogleOAuthAuthCode({
+                clientId: 'cid',
+                clientSecret: 'secret',
+                code: 'auth-code',
+                redirectUri: 'https://app.example.com/cb'
+            });
+            assert.equal(out.email, 'info@example.com');
+        });
+
+        it('enforces hosted domain from verified claims', async () => {
+            const { idToken, publicKey } = signedGoogleIdToken({
+                email: 'user@example.com',
+                email_verified: true,
+                hd: 'other.com'
+            });
+
+            globalThis.fetch = (async (input: string | URL) => {
+                const url = String(input);
+                if (url === 'https://oauth2.googleapis.com/token') {
+                    return new Response(JSON.stringify({ id_token: idToken }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (url === 'https://www.googleapis.com/oauth2/v1/certs') {
+                    return new Response(JSON.stringify({ 'test-key': publicKey }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                throw new Error(`unexpected fetch: ${url}`);
+            }) as typeof fetch;
+
+            const out = await exchangeGoogleOAuthAuthCode({
+                clientId: 'cid',
+                clientSecret: 'secret',
+                code: 'auth-code',
+                redirectUri: 'https://app.example.com/cb',
+                hostedDomain: 'example.com'
+            });
+            assert.equal(out.email, null);
         });
 
         it('falls back to userinfo when id_token has no email', async () => {

--- a/test/google-oauth.helper.test.ts
+++ b/test/google-oauth.helper.test.ts
@@ -150,7 +150,7 @@ describe('google-oauth.helper', () => {
             assert.equal(out.email, 'info@example.com');
         });
 
-        it('enforces hosted domain from verified claims', async () => {
+        it('enforces hosted domain from verified claims over userinfo fallback', async () => {
             const { idToken, publicKey } = signedGoogleIdToken({
                 email: 'user@example.com',
                 email_verified: true,
@@ -160,7 +160,7 @@ describe('google-oauth.helper', () => {
             globalThis.fetch = (async (input: string | URL) => {
                 const url = String(input);
                 if (url === 'https://oauth2.googleapis.com/token') {
-                    return new Response(JSON.stringify({ id_token: idToken }), {
+                    return new Response(JSON.stringify({ id_token: idToken, access_token: 'access-xyz' }), {
                         status: 200,
                         headers: { 'Content-Type': 'application/json' }
                     });
@@ -170,6 +170,15 @@ describe('google-oauth.helper', () => {
                         status: 200,
                         headers: { 'Content-Type': 'application/json' }
                     });
+                }
+                if (url === 'https://www.googleapis.com/oauth2/v3/userinfo') {
+                    return new Response(
+                        JSON.stringify({ email: 'user@example.com', verified_email: true, hd: 'example.com' }),
+                        {
+                            status: 200,
+                            headers: { 'Content-Type': 'application/json' }
+                        }
+                    );
                 }
                 throw new Error(`unexpected fetch: ${url}`);
             }) as typeof fetch;

--- a/test/google-oauth.helper.test.ts
+++ b/test/google-oauth.helper.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import assert from 'node:assert/strict';
+import {
+    buildGoogleOAuthAuthUrl,
+    exchangeGoogleOAuthAuthCode,
+    DEFAULT_GOOGLE_OAUTH_SCOPES
+} from '../src/modules/user/lib/google-oauth.helper.js';
+
+describe('google-oauth.helper', () => {
+    describe('buildGoogleOAuthAuthUrl', () => {
+        it('builds a valid Google authorization URL', () => {
+            const url = buildGoogleOAuthAuthUrl({
+                clientId: 'my-client-id',
+                redirectUri: 'https://app.example.com/login/azure-callback',
+                state: 'signed-state-jwt'
+            });
+            const parsed = new URL(url);
+            assert.equal(parsed.origin + parsed.pathname, 'https://accounts.google.com/o/oauth2/v2/auth');
+            assert.equal(parsed.searchParams.get('client_id'), 'my-client-id');
+            assert.equal(
+                parsed.searchParams.get('redirect_uri'),
+                'https://app.example.com/login/azure-callback'
+            );
+            assert.equal(parsed.searchParams.get('response_type'), 'code');
+            assert.equal(parsed.searchParams.get('state'), 'signed-state-jwt');
+            assert.equal(parsed.searchParams.get('scope'), DEFAULT_GOOGLE_OAUTH_SCOPES.join(' '));
+        });
+
+        it('includes hosted domain when provided', () => {
+            const url = buildGoogleOAuthAuthUrl({
+                clientId: 'cid',
+                redirectUri: 'https://app.example.com/cb',
+                state: 'st',
+                hostedDomain: 'example.com'
+            });
+            assert.equal(new URL(url).searchParams.get('hd'), 'example.com');
+        });
+
+        it('throws when required params are missing', () => {
+            assert.throws(
+                () =>
+                    buildGoogleOAuthAuthUrl({
+                        clientId: '',
+                        redirectUri: 'https://x/cb',
+                        state: 'st'
+                    }),
+                /clientId, redirectUri and state are required/
+            );
+        });
+    });
+
+    describe('exchangeGoogleOAuthAuthCode', () => {
+        const originalFetch = globalThis.fetch;
+
+        beforeEach(() => {
+            globalThis.fetch = originalFetch;
+        });
+
+        afterEach(() => {
+            globalThis.fetch = originalFetch;
+        });
+
+        it('returns email from id_token claims', async () => {
+            const idToken =
+                'eyJhbGciOiJSUzI1NiJ9.eyJlbWFpbCI6IlVzZXJAZXhhbXBsZS5DT00iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZX0.sig';
+
+            globalThis.fetch = (async (input: string | URL) => {
+                const url = String(input);
+                if (url === 'https://oauth2.googleapis.com/token') {
+                    return new Response(JSON.stringify({ id_token: idToken, access_token: 'at' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                throw new Error(`unexpected fetch: ${url}`);
+            }) as typeof fetch;
+
+            const out = await exchangeGoogleOAuthAuthCode({
+                clientId: 'cid',
+                clientSecret: 'secret',
+                code: 'auth-code',
+                redirectUri: 'https://app.example.com/cb'
+            });
+            assert.equal(out.email, 'user@example.com');
+        });
+
+        it('falls back to userinfo when id_token has no email', async () => {
+            globalThis.fetch = (async (input: string | URL) => {
+                const url = String(input);
+                if (url === 'https://oauth2.googleapis.com/token') {
+                    return new Response(JSON.stringify({ access_token: 'access-xyz' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (url === 'https://www.googleapis.com/oauth2/v3/userinfo') {
+                    return new Response(
+                        JSON.stringify({ email: 'info@example.com', verified_email: true }),
+                        {
+                            status: 200,
+                            headers: { 'Content-Type': 'application/json' }
+                        }
+                    );
+                }
+                throw new Error(`unexpected fetch: ${url}`);
+            }) as typeof fetch;
+
+            const out = await exchangeGoogleOAuthAuthCode({
+                clientId: 'cid',
+                clientSecret: 'secret',
+                code: 'auth-code',
+                redirectUri: 'https://app.example.com/cb'
+            });
+            assert.equal(out.email, 'info@example.com');
+        });
+
+        it('throws when token exchange fails', async () => {
+            globalThis.fetch = (async () =>
+                new Response('invalid_grant', { status: 400 })) as typeof fetch;
+
+            await assert.rejects(
+                () =>
+                    exchangeGoogleOAuthAuthCode({
+                        clientId: 'cid',
+                        clientSecret: 'secret',
+                        code: 'bad',
+                        redirectUri: 'https://app.example.com/cb'
+                    }),
+                /Google token exchange failed/
+            );
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
         "types": [
-            //"jest"
+            "node"
         ], /* Specify type package names to be included without being referenced in a source file. */
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
         // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a stateless Google OAuth 2.0 authorization-code helper to `@programisto/edrm-user`, exported as `@programisto/edrm-user/google-oauth`. No platform environment variables are required — callers pass `clientId` / `clientSecret` per request (used by internal-portal entity collaborator login).

## Changes

- `buildGoogleOAuthAuthUrl` — builds the Google consent URL
- `exchangeGoogleOAuthAuthCode` — exchanges the auth code and resolves the user email (id_token claims or userinfo fallback)
- Package export subpath `./google-oauth`
- Unit tests for URL building and token exchange (mocked fetch)
- Version bump `0.4.28` → `0.4.29`

## Consumer

Requires companion PR on `internal-portal` (`cursor/google-sso-entity-login-2034`) which wires marketplace config, API routes, and login UI.

## Publish order

1. Merge and publish this package (`0.4.29`)
2. Merge internal-portal PR and switch its dependency from `file:../../../edrm-user` to `^0.4.29` if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13a62441-4839-4585-975c-5020a5702034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13a62441-4839-4585-975c-5020a5702034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

